### PR TITLE
Fix the loading path of the main.js module

### DIFF
--- a/html/RenderDataJonas.html
+++ b/html/RenderDataJonas.html
@@ -47,7 +47,7 @@
         <p> &copy; Jonas and Selihom</p>
     </div>
 
-    <script  src="/js/main.js" type="module"></script>
+    <script  src="../js/main.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/html/RenderDataSeli.html
+++ b/html/RenderDataSeli.html
@@ -50,7 +50,7 @@
         <p> &copy; Jonas and Selihom</p>
     </div>
 
-    <script  src="/js/main.js" type="module"></script>
+    <script  src="../js/main.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
 
 </body>

--- a/html/contact.html
+++ b/html/contact.html
@@ -92,6 +92,6 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
-    <script src="/js/main.js" type="module"></script>
+    <script src="../js/main.js" type="module"></script>
   </body>
 </html>

--- a/html/details.html
+++ b/html/details.html
@@ -87,7 +87,7 @@
         <p> &copy; Jonas and Selihom</p>
     </div>
 
-    <script  src="/js/main.js" type="module"></script>
+    <script  src="../js/main.js" type="module"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js" integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/html/mapJon.html
+++ b/html/mapJon.html
@@ -59,6 +59,6 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
     integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
     crossorigin=""></script>
-    <script src="/js/main.js" type="module"></script>
+    <script src="../js/main.js" type="module"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
     </div>
   
   </footer>  
-  <script type="module" src="/js/main.js"></script>
+  <script type="module" src="js/main.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script> 
 </body>
 </html>


### PR DESCRIPTION
This PR contains:
- A fix that uses relative path (to the current HTML document) to link the `main.js` module. 

Note: When linking a script, use `./` or `../` should be used and not `/` as the latter points to the root directory of your GitHub Pages workspace. 
For example: use `<script src="../js/main.js">  </script>`, 

This will fix the page loading issue that you are currently encountering on GitHub Pages.

![image](https://github.com/user-attachments/assets/072283cc-593a-41b1-aac1-b20e019fb87f)
